### PR TITLE
Return $production_url when using constant

### DIFF
--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -201,7 +201,7 @@ class BE_Media_From_Production {
 	public function get_production_url() {
 		$production_url = $this->production_url;
 		if ( defined( 'BE_MEDIA_FROM_PRODUCTION_URL' ) && BE_MEDIA_FROM_PRODUCTION_URL ) {
-			$production_url = BE_MEDIA_FROM_PRODUCTION_URL;
+			return $production_url = BE_MEDIA_FROM_PRODUCTION_URL;
 		}
 
 		return apply_filters( 'be_media_from_production_url', $production_url );


### PR DESCRIPTION
Hi Bill,

It seems that the method get_production_url() doesn't return the actual url. This is because of be_media_from_production_url filter not added when using the BE_MEDIA_FROM_PRODUCTION_URL constant. we now return the $production_url when the constant is defined.